### PR TITLE
Add dev container configuration 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"build": { "dockerfile": "dockerfile" },
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "latest"
+		}
+	},
+	
+	"customizations": {
+	},
+
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,12 @@
 			"version": "latest"
 		}
 	},
-	
+
 	"customizations": {
 	},
 
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"mounts": [
+      "source=rackstack-bashhistory,target=/commandhistory,type=volume"
+  ]
 }

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+RUN wget -qO- https://files.openscad.org/OBS-Repository-Key.pub | sudo tee /etc/apt/trusted.gpg.d/obs-openscad-nightly.asc \
+    && echo "deb https://download.opensuse.org/repositories/home:/t-paul/Debian_12/ ./" >> /etc/apt/sources.list.d/openscad.list \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends openscad openscad-nightly

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -3,4 +3,18 @@ FROM mcr.microsoft.com/devcontainers/base:bookworm
 RUN wget -qO- https://files.openscad.org/OBS-Repository-Key.pub | sudo tee /etc/apt/trusted.gpg.d/obs-openscad-nightly.asc \
     && echo "deb https://download.opensuse.org/repositories/home:/t-paul/Debian_12/ ./" >> /etc/apt/sources.list.d/openscad.list \
     && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends openscad openscad-nightly
+    && apt-get -y install --no-install-recommends openscad openscad-nightly libpng-dev libjpeg-dev libtiff-dev
+
+
+RUN apt-get -y install --no-install-recommends imagemagick
+
+RUN curl -sL http://www.lcdf.org/gifsicle/gifsicle-1.91.tar.gz | tar -zx \
+    && cd gifsicle-1.91 \
+    && ./configure --disable-gifview \
+    && make install
+
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R $USERNAME /commandhistory \
+    && echo "$SNIPPET" >> "/home/$USERNAME/.bashrc"

--- a/rbuild.py
+++ b/rbuild.py
@@ -20,12 +20,20 @@ if os.name == "posix":
     else:  # Assume Linux if not macOS
         print("Operating System: Linux")
         PATH_TO_OPENSCAD = '/usr/bin/openscad'
-        PATH_TO_OPENSCAD_NIGHTLY = '/snap/bin/openscad-nightly'
+        
+        if binary_exists(PATH_TO_OPENSCAD):
+            print(f"Binary found at {PATH_TO_OPENSCAD}")
+        else:
+            print(f"Binary not found at {PATH_TO_OPENSCAD}")
 
-    if binary_exists(PATH_TO_OPENSCAD):
-        print(f"Binary found at {PATH_TO_OPENSCAD}")
-    else:
-        print(f"Binary not found at {PATH_TO_OPENSCAD}")
+        if binary_exists('/snap/bin/openscad-nightly'):
+            print(f"Nightly binary found at {PATH_TO_OPENSCAD}")
+            PATH_TO_OPENSCAD_NIGHTLY = '/snap/bin/openscad-nightly'
+        elif binary_exists('/usr/bin/openscad-nightly'):
+            print(f"Nightly binary found at {PATH_TO_OPENSCAD}")
+            PATH_TO_OPENSCAD_NIGHTLY = '/usr/bin/openscad-nightly'
+        else:
+            print('Nightly binary not installed')
 
 elif os.name == "nt":  # Windows
     print("Operating System: Windows")


### PR DESCRIPTION
Added setup for a debian dev container with python, openscad and openscad-nightly preinstalled and tooling required to generate gifs
Updated rbuild.py to look in in both the /snap/bin and /usr/bin directories for the installed instance of openscad-nightly

Example of a build running in github codespaces
![image](https://github.com/user-attachments/assets/80f47421-cb9e-49b5-838d-ba508347af22)

Duplicate of https://github.com/jazwa/rackstack/pull/21 but this is re-oppened because i destroyed that branch altering the git history.