### PR TITLE
update tray documentation to indicate the dimensions are including padding

### DIFF
--- a/rack-mount/tray/entry.scad
+++ b/rack-mount/tray/entry.scad
@@ -14,6 +14,8 @@ module traySystem (
 
 trayU = 2,
 
+// these dimensions are the total base width including padding not usable space. 
+// e.g. 145 baseWidth and 3 sideThickness = 145-(3*2) = 139mm useable space.
 baseWidth = 145,
 baseDepth = 100,
 


### PR DESCRIPTION
Added documentation to ensure anyone who prints the tray knows the usable space is less than the dimensions you specify in the build.