### PR TITLE
120mm Rear Case Fan / EQi12 Box / Unifi 8 Lite PoE Switch + Mounting Adapter

### DIFF
--- a/rack-mount/catalog/120mm-Rear-Case-Fan.scad
+++ b/rack-mount/catalog/120mm-Rear-Case-Fan.scad
@@ -1,0 +1,64 @@
+use <../tray/tray.scad>
+
+/*
+  Simple tray for a 120mm Case Fan.
+  Not compatible with nano rack configuration.
+  Designed to be mounted on the back in a reverse position, with the fan sitting on the outside of the case rather than the inside.
+  Mesh Screens are advised on the fore and aft of the fan.
+  Powered by USB to 3 or 2-pin connectors.
+  MINIMUM HEIGHT IS 13 TOTAL U's, which is showcased as u = 12 in rackstack.
+  
+  Please make sure to configure the correct rack frame dimensions in rackFrame.scad.
+*/
+
+
+difference () {
+    bottomScrewTray (
+        u = 12,
+        trayWidth = 130,
+        trayDepth = 35,
+        trayThickness = 3,
+        frontLipHeight = 126,
+        backLipHeight = 126,
+       // mountPoints = [[15, 15], [15+105, 15],[15, 15+105], [15+105, 15+105]],
+        frontThickness = 3,
+        sideThickness = 3,
+        mountPointElevation = 1,
+        mountPointType = "m4",
+        sideSupport = true,
+        trayLeftPadding = 25
+        );
+
+translate (v=[-5,10,-5])
+rotate (a=[90,0,0]) {
+    // Center Cutout
+    translate(v=[67.5, 67.5, -25])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cylinder(h=60, r1=60, r2=60, $fn=75);
+           
+    // fan screw hole 1
+    translate(v=[15, 15, -25])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cylinder(h=65, r1=2.5, r2=2.5, $fn=25);
+            
+    // fan screw hole 2
+    translate(v=[15+105, 15, -25])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cylinder(h=45, r1=2.5, r2=2.5, $fn=25);
+            
+    // fan screw hole 3
+    translate(v=[15+105, 15+105, -25])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cylinder(h=65, r1=2.5, r2=2.5, $fn=25);
+         
+    // fan screw hole 4
+    translate(v=[15, 15+105, -25])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cylinder(h=65, r1=2.5, r2=2.5, $fn=25);
+    }
+}

--- a/rack-mount/catalog/Unifi-8-PoE-Switch_Tray+Adapter.scad
+++ b/rack-mount/catalog/Unifi-8-PoE-Switch_Tray+Adapter.scad
@@ -1,0 +1,169 @@
+use <../tray/tray.scad>
+
+/*
+  Simple tray for a Unifi Lite 8PoE Switch.
+  Included mounting adapter, mounting adapter seats two M3 Hex nuts using two M3x8 screws.
+  DO NOT USE INCLUDED SCREWS FROM UNIFI, this will damage the switch.
+  
+  Please make sure to configure the correct rack frame dimensions in rackFrame.scad.
+*/
+
+
+///////////////////////////////////////
+/////////// MOUNTING TRAY //////////// 
+/////////////////////////////////////
+difference () {
+    bottomScrewTray (
+        u = 3,
+        trayWidth = 175,
+        trayDepth = 110,
+        trayThickness = 3,
+        frontLipHeight = 7.5,
+        backLipHeight = 7.5,
+        mountPoints = [[54, 40], [54+60.325, 40]],
+        frontThickness = 3,
+        sideThickness = 3,
+        mountPointElevation = 1,
+        mountPointType = "m3",
+        sideSupport = true,
+        trayLeftPadding = 2.5
+        );
+
+    // Front Center Cube
+    translate(v=[87.5, 20, -50])
+        rotate(a=[90,0,45])
+        rotate(a=[0,90,90])
+        cube(size=[12,12,135]);
+        
+    // Center Right Cube
+    translate(v=[58, 50, -50])
+        rotate(a=[90,0,45])
+        rotate(a=[0,90,90])
+        cube(size=[12,12,135]);
+        
+    // Center Left Cube
+    translate(v=[117.5, 50, -50])
+        rotate(a=[90,0,45])
+        rotate(a=[0,90,90])
+        cube(size=[12,12,135]);
+            
+    // Rear Left Cube
+    translate(v=[67.5, 60, -50])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cube(size=[12,12,135]);
+        
+    // Rear Center Cube
+    translate(v=[87.5, 77, -50])
+        rotate(a=[90,0,45])
+        rotate(a=[0,90,90])
+        cube(size=[12,12,135]);
+
+    // Rear Right Cube
+    translate(v=[103.5, 60, -50])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cube(size=[12,12,135]);
+            
+            
+    // Side Front Right Cube
+    translate(v=[132.5, 10, -50])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cube(size=[25,12,135]);
+            
+    // Side Front Left Cube
+    translate(v=[37.5, 10, -50])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cube(size=[25,12,135]);
+
+    // Side Rear Right Cube
+    translate(v=[132.5, 65, -50])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cube(size=[25,12,135]);
+            
+    // Side Rear Left Cube
+    translate(v=[38.5, 65, -50])
+        rotate(a=[90,0,0])
+        rotate(a=[0,90,90])
+        cube(size=[25,12,135]);
+        
+    }
+
+///////////////////////////////////////
+////////// MOUNTING ADAPTER ////////// 
+/////////////////////////////////////
+
+// Seat Teeth
+translate (v= [0,1.5,0.1,]){
+    translate(v=[54.25 + 15 -1.25, 5.5 + 13.51875, 10+2.25]) {
+        cube(size=[1.5875, 6.5, 1.5875]);
+    }
+    translate(v=[54.25 + 20 -1.25, 5.5 + 13.51875, 10+2.25]) {
+        cube(size=[1.5875, 6.5, 1.5875]);
+    }
+    translate(v=[54.25 + 25 -1.25, 5.5 + 13.51875, 10+2.25]) {
+        cube(size=[1.5875, 6.5, 1.5875]);
+    }
+
+    translate(v=[54.25 + 15 -1.25 + 22, 5.5 + 13.51875, 10+2.25]) {
+        cube(size=[1.5875, 6.5, 1.5875]);
+    }
+    translate(v=[54.25 + 20 -1.25 + 22, 5.5 + 13.51875, 10+2.25]) {
+        cube(size=[1.5875, 6.5, 1.5875]);
+    }
+    translate(v=[54.25 + 25 -1.25 + 22, 5.5 + 13.51875, 10+2.25]) {
+        cube(size=[1.5875, 6.5, 1.5875]);
+    }
+}
+
+// Seat Key
+difference () {
+    translate(v=[54.25, 5.5 + 13.51875, 10+3.175]) {
+        cube(size=[59.53125, 9.5, 1.5875]);
+    }
+    translate(v=[45 + 38.89375, 19, 12]) {
+        cube(size=[1.5875, 10, 4.7625]);
+    }
+}
+
+// Body
+difference () {
+    translate(v=[45, 28.5, 9 + 0.5125]) {
+        cube(size=[77.7875, 23.01875, 5.7625 - 0.5125]);
+    }
+
+
+// Cut aways    
+    translate(v=[45, 22, 0]) {    
+    rotate(a=[0,0,45]){
+        translate(v=[-.25, -.25, 9]) {
+        cube(size=[9.7525, 9.7525, 10]);
+    }
+}
+}  
+
+     translate(v=[45+ 77.7875, 22, 0]) {    
+    rotate(a=[0,0,45]){
+        translate(v=[-.25, -.25, 9]) {
+        cube(size=[9.7525, 9.7525, 10]);
+    }
+}
+}   
+// Screw holes 
+    translate(v=[54, 40, -10]) {
+            cylinder(h=65, r1=1.65, r2=1.65, $fn=25);
+    }
+
+    translate(v=[54+60.325, 40, -10]) {
+            cylinder(h=65, r1=1.65, r2=1.65, $fn=25);
+    }
+    translate(v=[54+60.325, 40, 12]) {
+            cylinder(h=65, r1=3.25, r2=3.25, $fn=6);
+    }
+    translate(v=[54, 40, 12]) {
+            cylinder(h=65, r1=3.25, r2=3.25, $fn=6);
+    }
+}

--- a/rack-mount/catalog/beelink-EQi12-box_mod.scad
+++ b/rack-mount/catalog/beelink-EQi12-box_mod.scad
@@ -1,0 +1,74 @@
+include <../../rack/sharedVariables.scad>
+include <../common.scad>
+include <../enclosed-box/helper.scad>
+
+use <../enclosed-box/sideRail.scad>
+use <../enclosed-box/frontBoxHolder.scad>
+
+/*
+  Enclosed box mounting system:
+  Helper file to use semi-enclosed side rails and a front plate to mount a box.
+  This system does not require any mounting holes on the enclosed box.
+
+  !!! Please also make sure that the correct rack frame preset is set in rackFrame.scad !!!
+*/
+module enclosedBoxSystem (
+
+// begin config ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Does not affect any part dimensions. Set this to true to visualize how a box would be mounted.
+visualize = false,
+zOrientation = "middle", // ["middle" | "bottom"]
+recessSideRail = false,
+
+boxWidth = 126,
+boxHeight = 44.5,
+boxDepth = 126,
+
+railDefaultThickness = 1.5,
+railSideThickness = 3,
+
+frontPlateThickness = 3,
+frontPlateCutoutYSpace = 3,
+frontPlateCutoutXSpace = 5,
+
+// end config //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+) {
+  leftRailTrans = identity;
+  rightRailTrans = visualize
+    ? translate(v = [boxWidth, 0, 0])*mirror(v = [1, 0, 0])
+    : translate(v = [sideRailBaseWidth*2, 0, 0])*mirror(v = [1, 0, 0]);
+
+  u = findU(boxHeight, railDefaultThickness);
+  railBottomThickness = railBottomThickness(u, boxHeight, railDefaultThickness, zOrientation);
+  frontBoxHolderTrans = visualize
+    ? translate(v = [railSideThickness-(railSupportsDx-boxWidth)/2, 0, sideRailLowerMountPointToBottom-
+      railBottomThickness])*mirror(v = [0, 1, 0])*rotate(a = [90, 0, 0])
+    : mirror(v = [0, 1, 0])*translate(v = [0, uDiff, frontPlateThickness-railBottomThickness]);
+
+  if (visualize) {
+    %cube(size = [boxWidth, boxDepth, boxHeight]);
+  }
+
+  multmatrix(leftRailTrans)
+    sideSupportRailBase(top = true, recess = recessSideRail, defaultThickness = railDefaultThickness, supportedZ =
+    boxHeight, supportedY = boxDepth, supportedX = boxWidth, zOrientation = zOrientation, railSideThickness =
+    railSideThickness);
+
+  multmatrix(rightRailTrans)
+    sideSupportRailBase(top = true, recess = recessSideRail, defaultThickness = railDefaultThickness, supportedZ =
+    boxHeight, supportedY = boxDepth, supportedX = boxWidth, zOrientation = zOrientation, railSideThickness =
+    railSideThickness);
+
+  multmatrix(frontBoxHolderTrans)
+    frontBoxHolder(
+    cutoutOffsetX = (rackMountScrewWidth-(boxWidth-2*frontPlateCutoutXSpace))/2, cutoutOffsetY = railBottomThickness+
+      frontPlateCutoutYSpace,
+    cutoutX = boxWidth-2*frontPlateCutoutXSpace, cutoutY = boxHeight-2*frontPlateCutoutYSpace,
+    zOrientation = zOrientation, supportedZ = boxHeight, supportWidth = max(10, boxWidth-(sideRailBaseWidth+10)),
+    supportRailDefaultThickness = railDefaultThickness, plateThickness = frontPlateThickness
+    );
+}
+
+enclosedBoxSystem();


### PR DESCRIPTION

![thumbnail_PXL_20250312_210004740 MP](https://github.com/user-attachments/assets/239f115b-8558-4824-8756-d3248a0c7883)
![thumbnail_PXL_20250312_205959573](https://github.com/user-attachments/assets/6d8a4aef-4882-414b-9d97-586bc9c1919e)
![thumbnail_PXL_20250312_210018680](https://github.com/user-attachments/assets/3df92cbf-d726-40a2-b56a-b75b8a2e5ca8)
120mm Rear Case Fan - Designed to be mounted on the rear face of the rack, with the case holding the fan on the exterior of the rack rather than the interior.

Beelink EQi12 Box - I originally created a Tray for the EQi12, but with it's lack of mounting points the device would shift. This box is the same as the enclosed box, however with the specific measurements of the EQi12.

![thumbnail_PXL_20250312_210117622](https://github.com/user-attachments/assets/e5590756-7baf-422e-80f2-61eb9d6106fd)
![thumbnail_PXL_20250312_210123884 MP](https://github.com/user-attachments/assets/f894d211-c838-4641-be13-dbc9260303c3)
![thumbnail_PXL_20250312_210128932](https://github.com/user-attachments/assets/f7169067-d23f-4630-a735-81ad1cf1ed3e)
![thumbnail_PXL_20250312_211656504 MP](https://github.com/user-attachments/assets/a5da79b0-8bd6-4fef-abb3-0820945fbd95)
![thumbnail_PXL_20250312_211712976](https://github.com/user-attachments/assets/591429a8-c36f-48ff-aaa4-a6a4a74019e0)

Unifi 8 port PoE Switch - I originally intended to use the Enclosed Box for this, however due to the bevels on every corner of this device, the box was unable to secure the switch. Instead, I created a custom mounting adapter to latch the switch to a tray, which is much easier to print and with less filament overall.